### PR TITLE
[Typo] A comment typo in workflowruntime_types.go

### DIFF
--- a/api/v1alpha1/workflowruntime_types.go
+++ b/api/v1alpha1/workflowruntime_types.go
@@ -78,7 +78,7 @@ type ProcessRuntimes map[string]ProcessRuntime
 
 // ProcessRuntime records the process runtime info
 type ProcessRuntime struct {
-	// Number is the number the processes run the same Function
+	// Number is the number of the processes running the same Function
 	Number int `json:"int"`
 	// TODO: Add more fileds
 }


### PR DESCRIPTION
The comment in workFlowRuntime Number filed has grammatical errors.

I made a simple correction